### PR TITLE
Optimise display_file

### DIFF
--- a/classes/course_format_data_common_trait.php
+++ b/classes/course_format_data_common_trait.php
@@ -68,50 +68,31 @@ class course_format_data_common_trait {
 
     /**
      * Display image file
+     * @param  context $context Course context
      * @param  int $itemid File item id
      * @return string      Image file url
      */
-    public function display_file($itemid) {
-        global $DB, $CFG;
-
-        // Added empty check here to check if 'remuicourseimage_filearea' is set or not.
-        if ( !empty($itemid) ) {
-            $filedata = $DB->get_records('files', array('itemid' => $itemid));
-
-            $tempdata = array();
-            foreach ($filedata as $key => $value) {
-                if ($value->filesize > 0 && $value->filearea == 'remuicourseimage_filearea') {
-                    $tempdata = $value;
-                }
-            }
-            $fs = get_file_storage();
-            if (!empty($tempdata)) {
-                $files = $fs->get_area_files(
-                    $tempdata->contextid,
-                    'format_remuiformat',
-                    'remuicourseimage_filearea',
-                    $itemid
-                );
-                $url = '';
-                foreach ($files as $key => $file) {
-                    $file->portfoliobutton = '';
-
-                    $path = '/'.
-                            $tempdata->contextid.
-                            '/'.
-                            'format_remuiformat'.
-                            '/'.
-                            'remuicourseimage_filearea'.
-                            '/'.
-                            $file->get_itemid().
-                            $file->get_filepath().
-                            $file->get_filename();
-                    $url = file_encode_url("$CFG->wwwroot/pluginfile.php", $path, true);
-                }
-                return $url;
-            }
+    public function display_file($context, $itemid) {
+        if (empty($itemid)) {
+            return '';
         }
-        return '';
+
+        $files = get_file_storage()->get_area_files(
+            $context->id, 'format_remuiformat', 'remuicourseimage_filearea',
+            $itemid, 'itemid, filepath, filename', false);
+
+        if (empty($files)) {
+            return '';
+        }
+
+        $file = current($files);
+        return \moodle_url::make_pluginfile_url(
+            $file->get_contextid(),
+            $file->get_component(),
+            $file->get_filearea(),
+            $file->get_itemid(),
+            $file->get_filepath(),
+            $file->get_filename(), false);
     }
 
     /**

--- a/classes/output/card_all_sections_summary_renderable.php
+++ b/classes/output/card_all_sections_summary_renderable.php
@@ -180,8 +180,7 @@ class format_remuiformat_card_all_sections_summary implements renderable, templa
                 $export->generalsection['fullsummary'] = $generalsectionsummary;
 
                 // Get course image if added.
-                $imgurl = $this->courseformatdatacommontrait->display_file($this->settings['remuicourseimage_filemanager']);
-                $imgurl = $this->courseformatdatacommontrait->display_file($this->settings['remuicourseimage_filemanager']);
+                $imgurl = $this->courseformatdatacommontrait->display_file($coursecontext, $this->settings['remuicourseimage_filemanager']);
                 if (empty($imgurl)) {
                     $imgurl = $this->courseformatdatacommontrait->get_dummy_image_for_id($this->course->id);
                 }

--- a/classes/output/list_all_sections_renderable.php
+++ b/classes/output/list_all_sections_renderable.php
@@ -156,7 +156,7 @@ class format_remuiformat_list_all_sections implements renderable, templatable {
         $export->courseid = $this->course->id;
 
         if (!$hidegeneralsection) {
-            $imgurl = $this->courseformatdatacommontrait->display_file($this->settings['remuicourseimage_filemanager']);
+            $imgurl = $this->courseformatdatacommontrait->display_file($coursecontext, $this->settings['remuicourseimage_filemanager']);
             // General Section Details.
             $generalsection = $modinfo->get_section_info(0);
             if ($editing) {

--- a/classes/output/list_all_sections_summary_renderable.php
+++ b/classes/output/list_all_sections_summary_renderable.php
@@ -154,8 +154,7 @@ class format_remuiformat_list_all_sections_summary implements renderable, templa
         $export->courseid = $this->course->id;
 
         if (!$hidegeneralsection) {
-
-            $imgurl = $this->courseformatdatacommontrait->display_file($this->settings['remuicourseimage_filemanager']);
+            $imgurl = $this->courseformatdatacommontrait->display_file($coursecontext, $this->settings['remuicourseimage_filemanager']);
 
             // General Section Details.
             $generalsection = $modinfo->get_section_info(0);


### PR DESCRIPTION
This fixes a few issues with display_file():
* it was iterating over items that belong to other courses
* itemid collisions meant it might try to load images belonging to other
  courses
* an unnecessary db lookup that wasn't hitting a table index could take 5+
  seconds to load
* the function was called twice in one instance to load the same url

On a large site - this change reduces the run time of display_file from 5+
seconds to less than 0.00009 seconds - 5 full orders of magnitude faster.