### PR TITLE
Add format option for displaying full content of selected modules

### DIFF
--- a/classes/output/card_one_section_renderable.php
+++ b/classes/output/card_one_section_renderable.php
@@ -218,10 +218,19 @@ class format_remuiformat_card_one_section implements renderable, templatable {
                 $activitydetails->title .= $mod->afterlink;
                 $activitydetails->modulename = $mod->modname;
                 $activitydetails->modulefullname = $mod->modfullname;
-                $activitydetails->summary = $this->modstats->get_formatted_summary(
-                    $this->courserenderer->course_section_cm_text($mod, $displayoptions),
-                    $this->settings
-                );
+
+                $modallowedfullcontent = isset($this->settings['activityfullcontent'])
+                    && in_array($mod->modname, explode(',', trim($this->settings['activityfullcontent'])));
+
+                if ($modallowedfullcontent) {
+                    $activitydetails->summary = $this->courserenderer->course_section_cm_text($mod, $displayoptions);
+                } else {
+                    $activitydetails->summary = $this->modstats->get_formatted_summary(
+                        $this->courserenderer->course_section_cm_text($mod, $displayoptions),
+                        $this->settings
+                    );
+                }
+
 
                 // In case of label activity send full text of cm to open in modal.
                 if (array_search($mod->modname, array('label', 'folder')) !== false) {

--- a/lang/en/format_remuiformat.php
+++ b/lang/en/format_remuiformat.php
@@ -55,6 +55,10 @@ $string['defaultsectionsummarymaxlength_desc'] = 'Set the the section/activities
 $string['hidegeneralsectionwhenempty'] = 'Hide general section when empty';
 $string['hidegeneralsectionwhenempty_help'] = 'When general section does not have any activity and summary then you can hide it.';
 
+$string['activityfullcontent'] = 'Activities/Resources with full content displayed';
+$string['activityfullcontent_help'] = 'A list of activities and resources for which the full content should be '
+    . 'displayed on cards. This includes label and folder by default.';
+
 // Section.
 $string['sectionname'] = 'Section';
 $string['sectionnamecaps'] = 'SECTION';

--- a/lib.php
+++ b/lib.php
@@ -242,6 +242,10 @@ class format_remuiformat extends format_base {
                     'default' => get_config('format_remuiformat', 'defaultsectionsummarymaxlength'),
                     'type' => PARAM_INT
                 ),
+                'activityfullcontent' => array(
+                    'default' => '',
+                    'type' => PARAM_TAGLIST
+                ),
                 'remuiteacherdisplay' => array(
                     'default' => 1,
                     'type' => PARAM_INT
@@ -328,6 +332,28 @@ class format_remuiformat extends format_base {
                     'label' => new lang_string('sectiontitlesummarymaxlength', 'format_remuiformat'),
                     'element_type' => 'text',
                     'help' => 'sectiontitlesummarymaxlength',
+                    'help_component' => 'format_remuiformat'
+                ),
+                'activityfullcontent' => array(
+                    'label' => new lang_string('activityfullcontent', 'format_remuiformat'),
+                    'element_type' => 'autocomplete',
+                    'element_attributes' => array(
+                        call_user_func(function () {
+                            $mods = array_map(
+                                function ($mod) {
+                                    return $mod->modname;
+                                },
+                                array_filter(get_course_mods($this->courseid), function ($mod) {
+                                    return ! in_array($mod->modname, array('label', 'folder'));
+                                })
+                            );
+                            return array_combine($mods, $mods);
+                        }),
+                        array(
+                            'multiple' => true,
+                        )
+                    ),
+                    'help' => 'activityfullcontent',
                     'help_component' => 'format_remuiformat'
                 ),
                 'remuiteacherdisplay' => array(
@@ -641,6 +667,8 @@ class format_remuiformat extends format_base {
             $data->remuicourseimage_filemanager = '';
         }
         if (!empty($data)) {
+
+            $data->activityfullcontent = implode(',', $data->activityfullcontent);
 
             // Used optional_param() instead of using $_POST and $_GET.
             $contextid = context_course::instance($this->courseid);


### PR DESCRIPTION
When using the card layout and single section per page, the content for some activities are not displayed properly, specifically the Face-to-Face activity as can be seen in the screenshot below from the Boost theme.

![image](https://user-images.githubusercontent.com/194185/135041056-4f5c5058-df81-47ff-9c48-0c9c388a6f76.png)

This pull request adds an additional setting (**Activities/Resources with full content displayed**) on the course Edit Settings page that allows the user to choose for which modules to display the full content in the card.

![image](https://user-images.githubusercontent.com/194185/135041344-0f9cffe8-8bf2-40a5-9ffd-910b3e575d7e.png)

When selecting facetoface for that setting, The Face-to-Face activity then displays as follows:

![image](https://user-images.githubusercontent.com/194185/135041896-0598be58-cc69-49b1-85ce-8097f67d63af.png)
