### PR TITLE
FIX #110 Strip HTML tags to ensure correct activity summary length

### DIFF
--- a/classes/mod_stats.php
+++ b/classes/mod_stats.php
@@ -69,7 +69,8 @@ class ModStats {
     public function get_formatted_summary($summary, $settings) {
         $output = '';
         $summarylength = $settings['sectiontitlesummarymaxlength'];
-        $summary = $summary;
+        //Strip all html tags, so the length of the text is correct
+        $summary = strip_tags($summary);
         if ($summary) {
             $end = "";
             if (strlen($summary) > $summarylength) {


### PR DESCRIPTION
This patch fixes issue #110 by introducing a call to the strip_tags() function to remove HTML tags before counting characters in the activity summary. This ensures that the summary length is calculated accurately, unaffected by HTML markup.